### PR TITLE
[Issue: #8] Updated pipeline worklow to prevent it from failing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Test:
-    uses: habetuz/TinfInfoUtils/.github/workflows/test.yml@main
+    uses: habetuz/CodingUtils/.github/workflows/test.yml@main
   Release:
     runs-on: ubuntu-latest
     needs: Test
@@ -31,11 +31,11 @@ jobs:
         if: steps.next_version.outputs.hasNextVersion == 'true'
         with:
           files: src/main/java/
-          dest: tinfUtils.zip
+          dest: CodingUtils.zip
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: steps.next_version.outputs.hasNextVersion == 'true'
         with:
-          artifacts: "tinfUtils.zip"
+          artifacts: "CodingUtils.zip"
           bodyFile: "release.md"
           tag: ${{ steps.next_version.outputs.version }}


### PR DESCRIPTION
## Description of Changes

I updated the release pipeline to the new repo name to prevent it from failing due to naming mismatches.

## Verify

- [x] The PR does not involve breaking changes, or the corresponding developers are informed and mentioned under "Reference"
- [x] Unit tests were added if needed
- [x] The code that is being added, was tested and no faults were found
- [x] The code that is being added, does not require external dependencies

## Reference

- Issue: #8  
- @habetuz (FYI, maybe check if all changes are correct)
